### PR TITLE
lib: move from asm! to llvm_asm!

### DIFF
--- a/libvmm_macros/src/lib.rs
+++ b/libvmm_macros/src/lib.rs
@@ -53,14 +53,14 @@ pub fn vmcs_access(args: TokenStream, input: TokenStream) -> TokenStream {
     let read_fn = quote! {
         pub fn read(&self) -> #vm_size {
             let mut value: u64;
-            unsafe { asm!("vmread $1, $0": "=r" (value): "r" (*self as u64)) };
+            unsafe { llvm_asm!("vmread $1, $0": "=r" (value): "r" (*self as u64)) };
             value as #vm_size
         }
     };
 
     let write_fn = quote! {
         pub fn write(&self, value: #vm_size) {
-            unsafe { asm!("vmwrite $0, $1":: "r" (value as u64), "r" (*self as u64)) };
+            unsafe { llvm_asm!("vmwrite $0, $1":: "r" (value as u64), "r" (*self as u64)) };
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(global_asm)]
 
 #[cfg(target_arch = "x86_64")]

--- a/src/x86_64/instructions/mod.rs
+++ b/src/x86_64/instructions/mod.rs
@@ -13,12 +13,12 @@ impl VMX {
             return false;
         }
 
-        asm!("vmxon $0":: "m" (address));
+        llvm_asm!("vmxon $0":: "m" (address));
         true
     }
 
     pub unsafe fn vmxoff() {
-        asm!("vmxoff");
+        llvm_asm!("vmxoff");
     }
 
     pub unsafe fn vmcall() {}

--- a/src/x86_64/instructions/msr.rs
+++ b/src/x86_64/instructions/msr.rs
@@ -32,7 +32,7 @@ impl MSR {
         let low: u32;
         let high: u32;
 
-        asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (*self) : "memory" : "volatile");
+        llvm_asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (*self) : "memory" : "volatile");
         ((high as u64) << 32) | (low as u64)
     }
 
@@ -40,6 +40,6 @@ impl MSR {
         let low = value as u32;
         let high = (value >> 32) as u32;
 
-        asm!("wrmsr" :: "{ecx}" (*self), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
+        llvm_asm!("wrmsr" :: "{ecx}" (*self), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
     }
 }

--- a/src/x86_64/instructions/vmcs.rs
+++ b/src/x86_64/instructions/vmcs.rs
@@ -392,14 +392,14 @@ impl VMCS {
         let error: bool;
         /* @todo seems to cause a compiler crash */
         //asm!("vmptrld $1; setna $0": "=qm" (error) : "m" (self.address));
-        unsafe { asm!("vmptrld $0":: "m" (self.address)) };
+        unsafe { llvm_asm!("vmptrld $0":: "m" (self.address)) };
 
         VMCSField64Host::RIP.write(vmx_return as u64);
         true
     }
 
     pub fn clear(&mut self) -> bool {
-        unsafe { asm!("vmclear $0":: "m" (self.address)) };
+        unsafe { llvm_asm!("vmclear $0":: "m" (self.address)) };
         self.launched = false;
         true
     }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -4,7 +4,7 @@
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 #![feature(alloc_error_handler)]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 extern crate alloc;
 extern crate bootloader;

--- a/testing/src/vmm.rs
+++ b/testing/src/vmm.rs
@@ -24,7 +24,7 @@ fn get_gdt() -> DescriptorTablePointer {
     let gdt = DescriptorTablePointer { base: 0, limit: 0 };
 
     unsafe {
-        asm!("sgdt ($0)":: "r"(&gdt): "memory");
+        llvm_asm!("sgdt ($0)":: "r"(&gdt): "memory");
     }
 
     gdt
@@ -34,7 +34,7 @@ fn get_idt() -> DescriptorTablePointer {
     let idt = DescriptorTablePointer { base: 0, limit: 0 };
 
     unsafe {
-        asm!("sidt ($0)":: "r"(&idt): "memory");
+        llvm_asm!("sidt ($0)":: "r"(&idt): "memory");
     }
 
     idt
@@ -42,49 +42,49 @@ fn get_idt() -> DescriptorTablePointer {
 
 fn get_cs() -> u16 {
     let segment: u16;
-    unsafe { asm!("mov %cs, $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("mov %cs, $0" : "=r" (segment) ) };
     segment
 }
 
 fn get_ds() -> u16 {
     let segment: u16;
-    unsafe { asm!("mov %ds, $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("mov %ds, $0" : "=r" (segment) ) };
     segment
 }
 
 fn get_es() -> u16 {
     let segment: u16;
-    unsafe { asm!("mov %es, $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("mov %es, $0" : "=r" (segment) ) };
     segment
 }
 
 fn get_fs() -> u16 {
     let segment: u16;
-    unsafe { asm!("mov %fs, $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("mov %fs, $0" : "=r" (segment) ) };
     segment
 }
 
 fn get_ss() -> u16 {
     let segment: u16;
-    unsafe { asm!("mov %ss, $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("mov %ss, $0" : "=r" (segment) ) };
     segment
 }
 
 fn get_gs() -> u16 {
     let segment: u16;
-    unsafe { asm!("mov %gs, $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("mov %gs, $0" : "=r" (segment) ) };
     segment
 }
 
 fn get_ldt() -> u16 {
     let segment: u16;
-    unsafe { asm!("sldt $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("sldt $0" : "=r" (segment) ) };
     segment
 }
 
 fn get_tr() -> u16 {
     let segment: u16;
-    unsafe { asm!("str $0" : "=r" (segment) ) };
+    unsafe { llvm_asm!("str $0" : "=r" (segment) ) };
     segment
 }
 
@@ -95,28 +95,28 @@ fn get_rflags() -> u64 {
 fn read_cr4() -> u64 {
     let value: u64;
     unsafe {
-        asm!("mov %cr4, $0" : "=r" (value));
+        llvm_asm!("mov %cr4, $0" : "=r" (value));
     }
     value
 }
 
 fn write_cr4(value: u64) {
     unsafe {
-        asm!("mov $0, %cr4" :: "r" (value));
+        llvm_asm!("mov $0, %cr4" :: "r" (value));
     }
 }
 
 fn read_cr3() -> u64 {
     let value: u64;
     unsafe {
-        asm!("mov %cr3, $0" : "=r" (value));
+        llvm_asm!("mov %cr3, $0" : "=r" (value));
     }
     value
 }
 
 fn write_cr3(value: u64) {
     unsafe {
-        asm!("mov $0, %cr3" :: "r" (value));
+        llvm_asm!("mov $0, %cr3" :: "r" (value));
     }
 }
 


### PR DESCRIPTION
Current project does not compile with rust 1.46 nightly because of new
asm syntax.

Rust 1.46 nightly introduced a new asm syntax and move the old syntax
under a new feature called llvm_asm. Since this feature is more like an
RFC let's not move to this new asm syntax instead use llvm_asm
everywhere.

More details can be found here:
https://blog.rust-lang.org/inside-rust/2020/06/08/new-inline-asm.html

Signed-off-by: Jinank Jain <jinank94@gmail.com>