### PR TITLE
testing: bump version of libos

### DIFF
--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["KarimAllah Ahmed <karim.allah.ahmed@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = { version = "0.6.4", features = ["map_physical_memory"]}
-x86_64 = "0.7.5"
+bootloader = { version = "0.9.4", features = ["map_physical_memory"]}
+x86_64 = "0.11.0"
 rlibc = "1.0.0"
 libvmm = { path = "../../libvmm" }
-libos = "0.1.2"
+libos = { version = "^0.1" }
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 
 [package.metadata.bootimage]


### PR DESCRIPTION
Before doing this we need to make sure that we publish the new version
of libos which is using llvm_asm instead asm. Also, update the other two crates (x86_64 and bootloader) to use new version asm.

Signed-off-by: Jinank Jain <jinank94@gmail.com>